### PR TITLE
Kick out broken base-prelude

### DIFF
--- a/.github/workflows/cabal-ci.yaml
+++ b/.github/workflows/cabal-ci.yaml
@@ -68,7 +68,24 @@ jobs:
         package txg
           ghc-options: -Wwarn
         allow-newer:
-          *:*
+          allow-newer:
+            token-bucket:*
+            thyme:*
+            servant-swagger:*
+            servant-server:*
+            servant-client-core:*
+            servant-client:*
+            servant:*
+            swagger2:*
+            paths:*
+            pact:*
+            *:lens
+            *:base
+            *:template-haskell
+            *:lens
+            *:haskeline
+            *:Cabal
+            *:ghc-prim
     - uses: actions/cache@v1
       name: Cache dist-newstyle
       with:

--- a/.github/workflows/cabal-ci.yaml
+++ b/.github/workflows/cabal-ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc: ['8.8.3', '8.10.1']
-        cabal: ['3.0']
+        cabal: ['3.2.0.0']
         os: ['ubuntu-18.04']
         cabalcache: ['true']
     env:

--- a/.github/workflows/cabal-ci.yaml
+++ b/.github/workflows/cabal-ci.yaml
@@ -68,7 +68,6 @@ jobs:
         package txg
           ghc-options: -Wwarn
         allow-newer:
-          allow-newer:
             token-bucket:*
             thyme:*
             servant-swagger:*

--- a/.github/workflows/cabal-ci.yaml
+++ b/.github/workflows/cabal-ci.yaml
@@ -22,12 +22,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.kadena_cabal_cache_aws_access_key_id }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.kadena_cabal_cache_aws_secret_access_key }}
 
-      # Cabal Cache
-      CABAL_CACHE: ./tmp/bin/cabal-cache
-      CABAL_CACHE_BUCKET: kadena-cabal-cache
-      SYNC_TO_CACHE: $CABAL_CACHE sync-to-archive --threads 16 --archive-uri s3://$CABAL_CACHE_BUCKET/${{ matrix.os }} --region us-east-1
-      SYNC_FROM_CACHE: $CABAL_CACHE sync-from-archive --threads 16 --archive-uri s3://$CABAL_CACHE_BUCKET/${{ matrix.os }} --region us-east-1
-
       # Aritfacts
       ARTIFACT_BUCKET: kadena-cabal-cache
       ARTIFACT_FOLDER: txg
@@ -36,28 +30,15 @@ jobs:
     # Setup
     - name: Checkout repository
       uses: actions/checkout@v1
-    - name: Install cabal-cache
-      if: matrix.cabalcache == 'true'
-      run: |
-        [[ "${{ matrix.os }}" =~ ubuntu ]] && OS="linux" || OS="osx"
-        mkdir -p "./tmp/bin"
-        curl -Ls "https://github.com/haskell-works/cabal-cache/releases/download/v1.0.1.5/cabal-cache_x86_64_${OS}.tar.gz" | tar -xzC "./tmp/bin/"
-    - name: Install Haskell (macOS)
-      if: contains(matrix.os, 'macOS')
-      run: |
-        curl -sL https://haskell.futurice.com/haskell-on-macos.py | python3 - --make-dirs --paths.d --ghc-alias=${{ matrix.ghc }} --cabal-alias=3.0.0.0 install ghc-${{ matrix.ghc }} cabal-install-3.0.0.0
-        ln -s /opt/cabal/3.0.0.0 /opt/cabal/3.0
-    - name: Install Haskell (ubuntu)
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-          sudo add-apt-repository ppa:hvr/ghc
-          sudo apt-get update
-          sudo apt-get install ghc-${{ matrix.ghc }}
-    - name: Set GHC and Cabal version
-      uses: actions/setup-haskell@v1
+    - name: Install GHC and Cabal
+      uses: actions/setup-haskell@v1.1.0
       with:
          ghc-version: ${{ matrix.ghc }}
          cabal-version: ${{ matrix.cabal }}
+    - name: Confirm GHC and Cabal installation
+      run: |
+        ghc --version
+        cabal --version
     - name: Install non-Haskell dependencies (ubuntu)
       if: contains(matrix.os, 'ubuntu')
       run: |
@@ -108,19 +89,22 @@ jobs:
     - name: Update package database
       run: cabal v2-update
     - name: Configure build
-      run: 'grep -q "ghc-${{ matrix.ghc }}" dist-newstyle/cache/plan.json || cabal v2-configure'
+      run: cabal v2-build all --dry-run
     - name: Sync from cabal cache
       if: matrix.cabalcache == 'true'
-      run: eval $SYNC_FROM_CACHE
+      uses: larskuhtz/cabal-cache-action@21220b9f6499bb12cb0b4b926d6faa9c46a7b146
+      with:
+        bucket: "kadena-cabal-cache"
+        region: "us-east-1"
+        folder: "${{ matrix.os }}"
+        aws_access_key_id: "${{ secrets.kadena_cabal_cache_aws_access_key_id }}"
+        aws_secret_access_key: "${{ secrets.kadena_cabal_cache_aws_secret_access_key }}"
     - name: Install build dependencies
       run: cabal v2-build --only-dependencies
     - name: Build
       run: cabal v2-build
     - name: Run Tests
       run: cabal v2-test
-    - name: Sync cabal cache
-      if: always() && (matrix.cabalcache == 'true')
-      run: eval $SYNC_TO_CACHE
 
     # Publish Artifacts
     - name: Prepare artifacts

--- a/.github/workflows/cabal-ci.yaml
+++ b/.github/workflows/cabal-ci.yaml
@@ -56,6 +56,8 @@ jobs:
         documentation: false
         executable-stripping: True
         library-stripping: True
+        constraints:
+          neat-interpolation < 0.4
         EOF
     - name: Append cabal.project for GHC-8.10
       if: contains(matrix.ghc, '8.10')
@@ -65,17 +67,8 @@ jobs:
           ghc-options: -Wwarn
         package txg
           ghc-options: -Wwarn
-        package cassava
-            flags: -bytestring--LT-0_10_4
         allow-newer:
           *:*
-        constraints:
-          megaparsec <8
-        source-repository-package
-          type: git
-          location: https://github.com/well-typed/optics
-          tag: 95760a121023b6314a1b1a92939fc97613ec5645
-          subdir: optics-core
     - uses: actions/cache@v1
       name: Cache dist-newstyle
       with:

--- a/lib/TXG/Repl.hs
+++ b/lib/TXG/Repl.hs
@@ -3,7 +3,6 @@
 -- in ghci.  Do not depend on this module from important code!
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -53,7 +52,6 @@ module TXG.Repl
   , module TXG.Simulate.Contracts.CoinContract
   ) where
 
-import           BasePrelude
 import           Control.Exception
 import           Control.Lens hiding (from, to, (.=))
 import           Control.Monad (forM)
@@ -65,7 +63,6 @@ import           Data.ByteString.Random
 import           Data.Decimal
 import           Data.Foldable
 import           Data.HashSet ()
-import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NEL
 import           Data.Maybe
 import           Data.Ratio
@@ -101,7 +98,7 @@ import           TXG.Utils
 
 -- Helper for simplifying construction of RequestKeys
 rk :: String -> RequestKeys
-rk s = RequestKeys $ fromString s :| []
+rk s = RequestKeys $ fromString s NEL.:| []
 
 host :: String -> HostAddress
 host h = HostAddress hn 443
@@ -230,7 +227,7 @@ pollResponse nw (Right rks) = do
 
 listenResponse :: Network -> Either ClientError RequestKeys -> IO ()
 listenResponse _nw (Left err) = putStrLn $ "There was a failure in the send: " ++ show err
-listenResponse nw (Right (RequestKeys (k :| []))) = do
+listenResponse nw (Right (RequestKeys (k NEL.:| []))) = do
   listResp <- pactListen nw k
   case listResp of
     Left err         -> putStrLn $ "Listen error: " ++ show err

--- a/lib/TXG/ReplInternals.hs
+++ b/lib/TXG/ReplInternals.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -8,7 +7,6 @@
 
 module TXG.ReplInternals where
 
-import           BasePrelude
 import           Control.Lens hiding ((.=))
 import           Control.Monad.State
 import           Data.Aeson
@@ -26,6 +24,7 @@ import           Pact.Types.ChainMeta
 import           Pact.Types.Command
 import           Pact.Types.Hash
 import           System.Random
+import           Text.Printf
 import           TXG.Simulate.Contracts.CoinContract
 import           TXG.Simulate.Contracts.Common
 import           TXG.Simulate.Contracts.HelloWorld

--- a/lib/TXG/Simulate/Contracts/CoinContract.hs
+++ b/lib/TXG/Simulate/Contracts/CoinContract.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 module TXG.Simulate.Contracts.CoinContract where
 
-import           BasePrelude
 import           Data.Aeson
+import           Data.Bool
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map.Strict as M
 import           Data.Text (Text)
@@ -16,6 +15,7 @@ import           Pact.Types.ChainId
 import           Pact.Types.ChainMeta (PublicMeta(..))
 import           Pact.Types.Command (Command(..), SomeKeyPairCaps)
 import           System.Random
+import           Text.Printf
 import           TXG.Simulate.Contracts.Common
 import           TXG.Simulate.Utils
 import           TXG.Utils
@@ -29,7 +29,7 @@ data CoinContractRequest
   | CoinTransferAndCreate SenderName ReceiverName Guard Amount
   deriving Show
 
-newtype Guard = Guard (NonEmpty SomeKeyPairCaps)
+newtype Guard = Guard (NEL.NonEmpty SomeKeyPairCaps)
 newtype SenderName = SenderName Account
 newtype ReceiverName = ReceiverName Account
 
@@ -45,7 +45,7 @@ instance Show ReceiverName where
 
 mkRandomCoinContractRequest
     :: Bool
-    -> M.Map Account (NonEmpty SomeKeyPairCaps)
+    -> M.Map Account (NEL.NonEmpty SomeKeyPairCaps)
     -> IO (FGen CoinContractRequest)
 mkRandomCoinContractRequest transfersPred kacts = do
     request <- bool (randomRIO @Int (0, 1)) (return 1) transfersPred

--- a/lib/TXG/Simulate/Contracts/HelloWorld.hs
+++ b/lib/TXG/Simulate/Contracts/HelloWorld.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes   #-}
 
@@ -14,19 +13,20 @@
 
 module TXG.Simulate.Contracts.HelloWorld where
 
-import           BasePrelude
 import           Data.Aeson
 import           Data.Default
 import qualified Data.List.NonEmpty as NEL
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Fake
+import           GHC.Generics
 import           Fake.Provider.Person.EN_US
 import           NeatInterpolation
 import           Pact.ApiReq (mkExec)
 import           Pact.Types.ChainId
 import           Pact.Types.ChainMeta (PublicMeta(..))
 import           Pact.Types.Command (Command(..), SomeKeyPairCaps)
+import           Text.Printf
 import           TXG.Simulate.Utils
 import           TXG.Utils
 
@@ -35,7 +35,7 @@ import           TXG.Utils
 helloWorldContractLoader
     :: ChainwebVersion
     -> PublicMeta
-    -> NonEmpty SomeKeyPairCaps
+    -> NEL.NonEmpty SomeKeyPairCaps
     -> IO (Command Text)
 helloWorldContractLoader v meta adminKS = do
   let theData = object ["admin-keyset" .= fmap (formatB16PubKey . fst) adminKS]

--- a/lib/TXG/Simulate/Contracts/SimplePayments.hs
+++ b/lib/TXG/Simulate/Contracts/SimplePayments.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes      #-}
 {-# LANGUAGE TypeApplications #-}
@@ -7,7 +6,6 @@
 -- |
 module TXG.Simulate.Contracts.SimplePayments where
 
-import           BasePrelude
 import           Data.Aeson
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map.Strict as M
@@ -20,13 +18,14 @@ import           Pact.Types.ChainId
 import           Pact.Types.ChainMeta (PublicMeta(..))
 import           Pact.Types.Command (Command(..), SomeKeyPairCaps)
 import           System.Random
+import           Text.Printf
 import           TXG.Simulate.Contracts.Common
 import           TXG.Simulate.Utils
 import           TXG.Utils
 
 ---
 
-simplePaymentsContractLoader :: ChainwebVersion -> PublicMeta -> NonEmpty SomeKeyPairCaps -> IO (Command Text)
+simplePaymentsContractLoader :: ChainwebVersion -> PublicMeta -> NEL.NonEmpty SomeKeyPairCaps -> IO (Command Text)
 simplePaymentsContractLoader v meta adminKS = do
     let theData = object ["admin-keyset" .= fmap (formatB16PubKey . fst) adminKS]
     mkExec (T.unpack theCode) theData meta (NEL.toList adminKS) (Just $ NetworkId $ chainwebVersionToText v) Nothing
@@ -83,7 +82,7 @@ simplePaymentsContractLoader v meta adminKS = do
   |]
 
 mkRandomSimplePaymentRequest
-  :: M.Map Account (NonEmpty SomeKeyPairCaps)
+  :: M.Map Account (NEL.NonEmpty SomeKeyPairCaps)
   -> IO (FGen SimplePaymentRequest)
 mkRandomSimplePaymentRequest _ = do
   request <- randomRIO @Int (0, 1)
@@ -109,13 +108,13 @@ mkRandomSimplePaymentRequest _ = do
 data SimplePaymentRequest
   = SPRequestGetBalance Account
   | SPRequestPay Account Account Amount
-  | SPCreateAccount Account Balance (NonEmpty SomeKeyPairCaps)
+  | SPCreateAccount Account Balance (NEL.NonEmpty SomeKeyPairCaps)
 
 simplePayReq
   :: ChainwebVersion
   -> PublicMeta
   -> SimplePaymentRequest
-  -> Maybe (NonEmpty SomeKeyPairCaps)
+  -> Maybe (NEL.NonEmpty SomeKeyPairCaps)
   -> IO (Command Text)
 simplePayReq v meta (SPCreateAccount (Account account) (Balance initBal) ks) _ = do
   adminKS <- testSomeKeyPairs

--- a/lib/TXG/Simulate/Utils.hs
+++ b/lib/TXG/Simulate/Utils.hs
@@ -1,9 +1,8 @@
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module TXG.Simulate.Utils where
 
-import           BasePrelude
+import           Control.Monad.IO.Class
 import           Data.Aeson
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16
@@ -22,13 +21,13 @@ import           TXG.Utils
 
 ---
 
-testApiKeyPairs :: NonEmpty ApiKeyPair
+testApiKeyPairs :: NEL.NonEmpty ApiKeyPair
 testApiKeyPairs =
   let (pub, priv, addr, scheme) = someED25519Pair
       apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme) Nothing
    in pure apiKP
 
-testSomeKeyPairs :: IO (NonEmpty SomeKeyPairCaps)
+testSomeKeyPairs :: IO (NEL.NonEmpty SomeKeyPairCaps)
 testSomeKeyPairs = do
     let (pub, priv, addr, scheme) = someED25519Pair
         apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme) Nothing
@@ -64,7 +63,7 @@ decodeKey = fst . B16.decode
 initAdminKeysetContract
     :: ChainwebVersion
     -> PublicMeta
-    -> NonEmpty SomeKeyPairCaps
+    -> NEL.NonEmpty SomeKeyPairCaps
     -> IO (Command Text)
 initAdminKeysetContract v meta adminKS =
   mkExec theCode theData meta (NEL.toList adminKS) (Just $ NetworkId $ chainwebVersionToText v) Nothing

--- a/lib/TXG/Utils.hs
+++ b/lib/TXG/Utils.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -56,20 +55,22 @@ module TXG.Utils
 , mempoolMember
 ) where
 
-import BasePrelude hiding (option)
-
 import Configuration.Utils
 
 import Control.Monad.Catch
 
+import Data.Bifunctor
 import qualified Data.ByteString as B
 import Data.ByteString.Base64.URL
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.List.NonEmpty as NEL
+import Data.Maybe
+import Data.String
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Data.Time.Clock.POSIX
 
+import GHC.Generics
 import GHC.Stack
 
 import Network.Connection
@@ -85,6 +86,8 @@ import Pact.Types.API
 import qualified Pact.Types.ChainMeta as CM
 import Pact.Types.Command
 import Pact.Types.Hash
+
+import Text.Read (readEither)
 
 -- -------------------------------------------------------------------------- --
 -- Chainweb Version

--- a/txg.cabal
+++ b/txg.cabal
@@ -15,9 +15,6 @@ extra-source-files:
 
 common commons
   default-language:   Haskell2010
-  default-extensions:
-    NoImplicitPrelude
-    OverloadedStrings
 
   ghc-options:
     -Wall
@@ -34,7 +31,6 @@ common commons
     , base                  >=4.7  && <5
     , base16-bytestring     >=0.1
     , base64                >=0.4
-    , base-prelude          >=1.3
     , bytestring
     , configuration-tools   >=0.4
     , connection            >=0.3


### PR DESCRIPTION
This PR fixes:

```
exec/TXG.hs:325:36: error:
    • Couldn't match type ‘Item
                             (NESeq
                                (ChainId,
                                 Map
                                   Sim.Account (Map Sim.ContractName (NonEmpty SomeKeyPairCaps))))’
                     with ‘(ChainId,
                            Map Sim.Account (Map Sim.ContractName (NonEmpty SomeKeyPairCaps)))’
      Expected type: NESeq
                       (ChainId,
                        Map Sim.Account (Map Sim.ContractName (NonEmpty SomeKeyPairCaps)))
                     -> [(ChainId,
                          Map Sim.Account (Map Sim.ContractName (NonEmpty SomeKeyPairCaps)))]
        Actual type: NESeq
                       (ChainId,
                        Map Sim.Account (Map Sim.ContractName (NonEmpty SomeKeyPairCaps)))
                     -> [Item
                           (NESeq
                              (ChainId,
                               Map
                                 Sim.Account (Map Sim.ContractName (NonEmpty SomeKeyPairCaps))))]
    • In the second argument of ‘(.)’, namely ‘toList’
      In the first argument of ‘fmap’, namely ‘(M.fromList . toList)’
      In the first argument of ‘(.)’, namely ‘fmap (M.fromList . toList)’
    |
325 |   accountMap <- fmap (M.fromList . toList) . forM chains $ \cid -> do
    |                                    ^^^^^^
```