### PR TITLE
TXG: add docker image for txg & print mempool related stats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:20.04
+
+RUN apt-get -y update && \
+    apt-get -y install curl && \
+    apt-get -y install cabal-install && \
+    apt-get -y install z3 && \
+    apt-get -y install git && \
+    rm -rf /var/cache/apt/lists
+
+RUN apt-get -y install ghc
+RUN apt-get -y install zlib1g-dev libsqlite3-dev
+
+RUN git clone https://github.com/kadena-io/txg.git
+
+WORKDIR /txg
+
+RUN cabal update
+RUN cabal new-build
+RUN cp ./dist-newstyle/build/x86_64-linux/ghc-8.6.5/txg-1.0.0/x/mempool-p2p-tester/build/mempool-p2p-tester/mempool-p2p-tester .
+RUN strip -s mempool-p2p-tester
+
+ENTRYPOINT ["/txg/mempool-p2p-tester"]
+CMD ["--help"]

--- a/deploy-contracts-template.yaml
+++ b/deploy-contracts-template.yaml
@@ -1,0 +1,14 @@
+isChainweb: true
+verbose:
+  verbosity: false
+batchSize: 1
+chainwebVersion: development
+scriptCommand:
+  tag: DeployContracts
+  contents: {"sendTxsAtHeight":5, "contractNames": ["guards", "fungible-util", "pactAgent18", "simpleSales20"]}
+nodeChainIds: [0]
+logHandle: stdout
+chainwebHosts:
+- hostname: mining-node
+  p2pPort: 1789
+  servicePort: 1848

--- a/deps/pact/github.json
+++ b/deps/pact/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "kadena-io",
   "repo": "pact",
-  "branch": "rel/v4.1.2",
+  "branch": "master",
   "private": false,
-  "rev": "51f8d6eeca1a8cff11d2fda5446522a4148f785c",
-  "sha256": "0zrc720f86zz2zqbmcmc8qh84fwsx6hdmlwi0n9cdi38yz3ybkcq"
+  "rev": "0a4bfe6b9b7edb8dfb44d5ed1ce5991ed87f199a",
+  "sha256": "1r8lrby9ygg35yh2pvfmirhjcsm0m5c4b317ik13809vd5kknzmz"
 }

--- a/exec/MPT.hs
+++ b/exec/MPT.hs
@@ -82,7 +82,7 @@ import           TXG.Simulate.Contracts.CoinContract
 import qualified TXG.Simulate.Contracts.Common as Sim
 import           TXG.Simulate.Contracts.HelloWorld
 import           TXG.Simulate.Contracts.SimplePayments
-import           TXG.Types
+import           TXG.Types hiding (PollMap, toNodeData)
 import           TXG.Utils
 import           MPT.Types
 
@@ -136,6 +136,7 @@ worker config = do
           , confGasLimit = mpt_gasLimit config
           , confGasPrice = mpt_gasPrice config
           , confTTL = mpt_timetolive config
+          , confTrackMempoolStat = False -- this will be ignored
           }
       cids <- newIORef $ NES.fromList $ NEL.fromList $ mpt_nodeChainIds config
       _ <- liftIO $ forkFinally (pollLoop cids (mpt_confirmationDepth config) (mpt_dbFile config) (mpt_pollDelay config) tcut trkeys cfg) $ either throwIO pure
@@ -248,6 +249,7 @@ mkMPTConfig mdistribution manager mpt_config hostAddr =
     , confGasLimit = mpt_gasLimit mpt_config
     , confGasPrice = mpt_gasPrice mpt_config
     , confTTL = mpt_timetolive mpt_config
+    , confTrackMempoolStat = False -- this will be ignored
     }
 
 data ApiError = ApiError
@@ -329,7 +331,7 @@ loop nodekey dbFile confirmationDepth tcut f = forever $ do
       lift . logg Error $ T.pack (show servantError)
     Right rks -> do
       countTV <- gets mptCounter
-      trkeys <- gets mptPollMap
+      _trkeys <- gets mptPollMap
       batch <- asks confBatchSize
       liftIO . atomically $ modifyTVar' countTV (+ fromIntegral batch)
       count <- liftIO $ readTVarIO countTV

--- a/exec/MPT.hs
+++ b/exec/MPT.hs
@@ -107,6 +107,7 @@ worker config = do
     tv  <- newTVarIO 0
     trkeys <- newTVarIO $ M.fromList $ zip (zipWith toNodeData [1..] (mpt_hosts config)) (repeat $ M.fromList $ zip (mpt_nodeChainIds config) (repeat mempty))
     mgr <- unsafeManager
+    createNodeTable (T.unpack $ mpt_dbFile config)
     createMempoolStatTable (T.unpack $ mpt_dbFile config)
     let policy :: RetryPolicyM IO
         policy = exponentialBackoff 250_000 <> limitRetries 3

--- a/exec/MPT.hs
+++ b/exec/MPT.hs
@@ -66,7 +66,6 @@ import qualified Pact.Types.ChainMeta as CM
 import           Pact.Types.Command
 import           Pact.Types.Exp (Literal(..))
 import           Pact.Types.Gas
-import qualified Pact.Types.Hash as H
 import           Pact.Types.Info (mkInfo)
 import           Pact.Types.Names
 import           Pact.Types.PactValue
@@ -560,7 +559,7 @@ trackTime act = do
   return (r,t1,t2)
 
 instance SQL.ToRow MempoolStat where
-  toRow (MempoolStat (ChainId cid) (RequestKey rk) ms) = SQL.toRow (H.unHash rk, cid, ty, s, e)
+  toRow (MempoolStat (ChainId cid) (RequestKey rk) ms) = SQL.toRow (show rk, cid, ty, s, e)
     where
       (ty,s,e) =
         case ms of

--- a/exec/MPT/Types.hs
+++ b/exec/MPT/Types.hs
@@ -51,27 +51,6 @@ import           TXG.Utils
 -- Args
 -------
 
-data ChainwebHost = ChainwebHost
-  {
-    cwh_hostname :: Hostname
-  , cwh_p2pPort :: Port
-  , cwh_servicePort :: Port
-  } deriving (Show, Generic)
-
-
-instance ToJSON ChainwebHost where
-  toJSON o = object
-    [
-      "hostname" .= cwh_hostname o
-    , "p2pPort" .= cwh_p2pPort o
-    , "servicePort" .= cwh_servicePort o
-    ]
-
-instance FromJSON ChainwebHost where
-  parseJSON = withObject "ChainwebHost" $ \o -> ChainwebHost
-    <$> o .: "hostname"
-    <*> o .: "p2pPort"
-    <*> o .: "servicePort"
 
 data MPTArgs = MPTArgs
   {

--- a/exec/MPT/Types.hs
+++ b/exec/MPT/Types.hs
@@ -27,12 +27,15 @@ import           Data.Bifunctor
 import qualified Data.ByteString.Lazy as LB
 import           Data.Decimal
 import           Data.Generics.Product.Fields (field)
+import           Data.Int
+import           Data.Map (Map)
 import           Data.Sequence.NonEmpty (NESeq(..))
 import qualified Data.Text as T
 import           GHC.Generics
 import           Network.HostAddress
 import qualified Options.Applicative as O
 import           Pact.Parse
+import           Pact.Types.API
 import           Pact.Types.ChainMeta
 import           Pact.Types.Gas
 import           System.Random.MWC (Gen)
@@ -81,6 +84,7 @@ data MPTArgs = MPTArgs
   , mpt_nodeVersion       :: !ChainwebVersion
   , mpt_nodeChainIds      :: [ChainId]
   , mpt_dbFile            :: !T.Text
+  , mpt_pollDelay         :: !Int -- in seconds
   } deriving (Show, Generic)
 
 
@@ -99,6 +103,7 @@ instance ToJSON MPTArgs where
     , "nodeVersion"       .= mpt_nodeVersion o
     , "nodeChainIds"      .= mpt_nodeChainIds o
     , "dbFile"            .= mpt_dbFile o
+    , "pollDelay"         .= mpt_pollDelay o
     ]
 
 instance FromJSON (MPTArgs -> MPTArgs) where
@@ -115,6 +120,7 @@ instance FromJSON (MPTArgs -> MPTArgs) where
     <*< field @"mpt_nodeVersion" ..: "nodeVersion" % o
     <*< field @"mpt_nodeChainIds" ..: "nodeChainIds" % o
     <*< field @"mpt_dbFile" ..: "dbFile" % o
+    <*< field @"mpt_pollDelay" ..: "pollDelay" % o
 
 defaultMPTArgs :: MPTArgs
 defaultMPTArgs = MPTArgs
@@ -131,6 +137,7 @@ defaultMPTArgs = MPTArgs
   , mpt_nodeVersion       = Development
   , mpt_nodeChainIds       = []
   , mpt_dbFile          = "mpt-data.sql"
+  , mpt_pollDelay       = 15
   }
 
 mpt_scriptConfigParser :: MParser MPTArgs
@@ -176,6 +183,10 @@ mpt_scriptConfigParser = id
     % long "db-file"
     <> metavar "FILEPATH"
     <> help "File name for sqlite database."
+  <*< field @"mpt_pollDelay" .:: option auto
+    % long "poll-delay"
+    <> metavar "SECONDS"
+    <> help "Time delay between sucessive polls on request keys(s)"
   where
     read' :: Read a => String -> ReadM a
     read' msg = eitherReader (bimap (const msg) id . readEither)
@@ -214,5 +225,15 @@ data MPTState = MPTState
   { mptGen    :: !(Gen (PrimState IO))
   , mptCounter :: !(TVar TXCount)
   , mptLatestCut :: !(TVar Cut)
+  , mptPollMap :: !(TVar PollMap)
   , mptChains :: !(NESeq ChainId)
   } deriving (Generic)
+
+
+type PollMap = Map ChainId [(TimeSpan, RequestKeys)]
+
+data TimeSpan = TimeSpan
+  {
+    start_time :: Int64
+  , end_time :: Int64
+  } deriving Show

--- a/exec/MPT/Types.hs
+++ b/exec/MPT/Types.hs
@@ -44,7 +44,7 @@ import           System.Random.MWC (Gen)
 import           Text.Read (readEither)
 import           Text.Printf
 import qualified TXG.Simulate.Contracts.Common as Sim
-import           TXG.Types
+import           TXG.Types hiding (PollMap)
 import           TXG.Utils
 
 -------

--- a/exec/TXG.hs
+++ b/exec/TXG.hs
@@ -446,7 +446,8 @@ type ContractLoader
 
 loadContracts :: Args -> ChainwebHost -> NEL.NonEmpty ContractLoader -> IO ()
 loadContracts config (ChainwebHost h _p2p service) contractLoaders = do
-  conf@(TXGConfig _ _ _ _ _ _ (Verbose vb) tgasLimit tgasPrice ttl') <- mkTXGConfig Nothing config (HostAddress h service)
+  conf@(TXGConfig _ _ _ _ _ _ (Verbose vb) tgasLimit tgasPrice ttl' _trackMempoolStat)
+        <- mkTXGConfig Nothing config (HostAddress h service)
   forM_ (nodeChainIds config) $ \cid -> do
     !meta <- Sim.makeMeta cid ttl' tgasPrice tgasLimit
     ts <- testSomeKeyPairs
@@ -492,7 +493,8 @@ data ApiError = ApiError
 
 loadContractsAtHeight :: Args -> Integer -> ChainwebHost -> NEL.NonEmpty ContractLoader -> IO ()
 loadContractsAtHeight config height (ChainwebHost host p2p service) contractLoaders = do
-  conf@(TXGConfig _ _ _ _ _ _ (Verbose vb) tgasLimit tgasPrice ttl') <- mkTXGConfig Nothing config (HostAddress host service)
+  conf@(TXGConfig _ _ _ _ _ _ (Verbose vb) tgasLimit tgasPrice ttl' _trackMempoolStat)
+        <- mkTXGConfig Nothing config (HostAddress host service)
   fix $ \fixloop -> do
     -- query the latest cut
     ecut <- queryCut (confManager conf) (HostAddress host p2p) (confVersion conf)
@@ -525,7 +527,8 @@ realTransactions
   -> TimingDistribution
   -> LoggerT T.Text IO ()
 realTransactions config (ChainwebHost h _p2p service) tv distribution = do
-  cfg@(TXGConfig _ _ _ _ v _ _ tgasLimit tgasPrice ttl') <- liftIO $ mkTXGConfig (Just distribution) config (HostAddress h service)
+  cfg@(TXGConfig _ _ _ _ v _ _ tgasLimit tgasPrice ttl' _trackMempoolStat)
+        <- liftIO $ mkTXGConfig (Just distribution) config (HostAddress h service)
 
   let chains = maybe (versionChains $ nodeVersion config) NES.fromList
                . NEL.nonEmpty

--- a/exec/TXG.hs
+++ b/exec/TXG.hs
@@ -578,7 +578,7 @@ realXChainCoinTransactions
   -> TimingDistribution
   -> LoggerT T.Text IO ()
 realXChainCoinTransactions config (ChainwebHost h _p2p service) tv distribution = do
-    when (null $ drop 1 $ nodeChainIds config) $ fail "You must specify at least 2 chains for cross-chain transfers"
+    when (null $ drop 1 $ nodeChainIds config) $ liftIO $ fail "You must specify at least 2 chains for cross-chain transfers"
     cfg <- liftIO $ mkTXGConfig (Just distribution) config (HostAddress h service)
     let chains = maybe (versionChains $ nodeVersion config) NES.fromList
                 . NEL.nonEmpty

--- a/exec/TXG/Types.hs
+++ b/exec/TXG/Types.hs
@@ -101,6 +101,7 @@ data TXCmd
   = DeployContracts [Sim.ContractName]
   | RunStandardContracts TimingDistribution
   | RunCoinContract TimingDistribution
+  | RunXChainTransfer TimingDistribution
   | RunSimpleExpressions TimingDistribution
   | PollRequestKeys Text
   | ListenerRequestKey Text

--- a/exec/TXG/Types.hs
+++ b/exec/TXG/Types.hs
@@ -44,8 +44,6 @@ module TXG.Types
   , ChainwebHost(..)
   , TXCount(..)
   , BatchSize(..)
-  , ContractKeyset(..)
-  , DeployContractsArgs(..)
   , PollMap
   , Verbose(..)
   , nelReplicate
@@ -81,7 +79,6 @@ import           Pact.Parse
 import           Pact.Types.API
 import           Pact.Types.ChainMeta
 import           Pact.Types.Command (SomeKeyPairCaps)
-import           Pact.Types.Crypto ()
 import           Pact.Types.Gas
 import           System.Random.MWC (Gen)
 import           Text.Read (readEither)
@@ -108,34 +105,8 @@ data Uniform = Uniform { low :: !Double, high :: !Double }
 defaultTimingDist :: TimingDistribution
 defaultTimingDist = GaussianTD $ Gaussian 1000000 (1000000 / 16)
 
-
-data ContractKeyset = ContractKeyset
-  {
-    cks_keysetName :: Text
-  , cks_keysetFiles :: [FilePath]
-  } deriving (Eq, Show, Generic)
-
-instance ToJSON ContractKeyset where
-  toJSON o = object
-    [
-      "keysetName" .= cks_keysetName o
-    , "keysetFiles" .= cks_keysetFiles o
-    ]
-
-instance FromJSON ContractKeyset where
-  parseJSON = withObject "ContractKeyset" $ \o -> ContractKeyset
-    <$> o .: "keysetName"
-    <*> o .: "keysetFiles"
-
-data DeployContractsArgs =
-   DeployContractsArgs
-   {
-     sendContractsAtHeight :: Integer
-   , contractNamesAndKeys :: Map Sim.ContractName [ContractKeyset]
-   } deriving (Eq, Show, Generic, FromJSON, ToJSON)
-
 data TXCmd
-  = DeployContracts DeployContractsArgs
+  = DeployContracts [Sim.ContractName]
   | RunStandardContracts TimingDistribution
   | RunCoinContract TimingDistribution
   | RunXChainTransfer TimingDistribution

--- a/exec/TXG/Types.hs
+++ b/exec/TXG/Types.hs
@@ -230,6 +230,7 @@ data Args = Args
   , gasPrice        :: GasPrice
   , timetolive      :: TTLSeconds
   , trackMempoolStat :: !Bool
+  , confirmationDepth :: !Int
   } deriving (Show, Generic)
 
 instance ToJSON Args where
@@ -245,6 +246,7 @@ instance ToJSON Args where
     , "gasPrice"        .= gasPrice o
     , "timetolive"      .= timetolive o
     , "trackMempoolStat" .= trackMempoolStat o
+    , "confirmationDepth" .= confirmationDepth o
     ]
 
 instance FromJSON (Args -> Args) where
@@ -260,6 +262,7 @@ instance FromJSON (Args -> Args) where
     <*< field @"gasPrice"        ..: "gasPrice"        % o
     <*< field @"timetolive"      ..: "timetolive"      % o
     <*< field @"trackMempoolStat" ..: "trackMempoolStat" %o
+    <*< field @"confirmationDepth" ..: "confirmationDepth" %o
 
 defaultArgs :: Args
 defaultArgs = Args
@@ -274,6 +277,7 @@ defaultArgs = Args
   , gasPrice = Sim.defGasPrice
   , timetolive = Sim.defTTL
   , trackMempoolStat = False
+  , confirmationDepth = 6
   }
   where
     v :: ChainwebVersion
@@ -319,6 +323,10 @@ scriptConfigParser = id
       % long "track-mempool-stat"
       <> metavar "BOOL"
       <> help "Wether to print out mempool related statistics"
+  <*< field @"confirmationDepth" .:: option auto
+      % long "confirmation-depth"
+      <> metavar "INT"
+      <> help "Confirmation depth"
   where
     read' :: Read a => String -> ReadM a
     read' msg = eitherReader (bimap (const msg) id . readEither)

--- a/exec/TXG/Types.hs
+++ b/exec/TXG/Types.hs
@@ -44,6 +44,7 @@ module TXG.Types
   , ChainwebHost(..)
   , TXCount(..)
   , BatchSize(..)
+  , ContractKeyset(..)
   , DeployContractsArgs(..)
   , Verbose(..)
   , nelReplicate
@@ -74,6 +75,8 @@ import qualified Options.Applicative as O
 import           Pact.Parse
 import           Pact.Types.ChainMeta
 import           Pact.Types.Command (SomeKeyPairCaps)
+import           Pact.Types.Crypto
+    (PPKScheme(..), PrivateKeyBS(..), PublicKeyBS(..), SomeKeyPair)
 import           Pact.Types.Gas
 import           System.Random.MWC (Gen)
 import           Text.Read (readEither)
@@ -99,11 +102,30 @@ data Uniform = Uniform { low :: !Double, high :: !Double }
 defaultTimingDist :: TimingDistribution
 defaultTimingDist = GaussianTD $ Gaussian 1000000 (1000000 / 16)
 
+
+data ContractKeyset = ContractKeyset
+  {
+    cks_keysetName :: Text
+  , cks_keysetFiles :: [FilePath]
+  } deriving (Eq, Show, Generic)
+
+instance ToJSON ContractKeyset where
+  toJSON o = object
+    [
+      "keysetName" .= cks_keysetName o
+    , "keysetFiles" .= cks_keysetFiles o
+    ]
+
+instance FromJSON ContractKeyset where
+  parseJSON = withObject "ContractKeyset" $ \o -> ContractKeyset
+    <$> o .: "keysetName"
+    <*> o .: "keysetFiles"
+
 data DeployContractsArgs =
    DeployContractsArgs
    {
-     sendTxsAtHeight :: Integer
-   , contractNames :: [Sim.ContractName]
+     sendContractsAtHeight :: Integer
+   , contractNamesAndKeys :: Map Sim.ContractName [ContractKeyset]
    } deriving (Eq, Show, Generic, FromJSON, ToJSON)
 
 data TXCmd

--- a/lib/TXG/ReplInternals.hs
+++ b/lib/TXG/ReplInternals.hs
@@ -23,6 +23,7 @@ import           Pact.Types.ChainId (NetworkId(..))
 import           Pact.Types.ChainMeta
 import           Pact.Types.Command
 import           Pact.Types.Hash
+import           Pact.Types.SPV
 import           System.Random
 import           Text.Printf
 import           TXG.Simulate.Contracts.CoinContract
@@ -75,6 +76,17 @@ pactPoll
     -> RequestKeys
     -> IO (Either ClientError PollResponses)
 pactPoll n rkeys = pactPostNetwork n "/poll" $ Poll (_rkRequestKeys rkeys)
+
+pactSPV
+    :: Network
+    -> RequestKey
+    -> ChainId
+    -> IO (Either ClientError ContProof)
+pactSPV n rkey targetChain = pactPostNetwork n "/spv" $ object
+    [
+     "requestKey" .= rkey
+    , "targetChainId" .= targetChain
+    ]
 
 pactLocal
     :: Network

--- a/lib/TXG/Simulate/Contracts/Common.hs
+++ b/lib/TXG/Simulate/Contracts/Common.hs
@@ -220,7 +220,9 @@ newtype ContractName = ContractName { getContractName :: String }
   deriving newtype Read
   deriving newtype IsString
   deriving newtype ToJSON
+  deriving newtype ToJSONKey
   deriving newtype FromJSON
+  deriving newtype FromJSONKey
 
 -- instance ToJSON ContractName
 

--- a/lib/TXG/Simulate/Contracts/Common.hs
+++ b/lib/TXG/Simulate/Contracts/Common.hs
@@ -219,10 +219,12 @@ newtype ContractName = ContractName { getContractName :: String }
   deriving (Eq, Ord, Show, Generic)
   deriving newtype Read
   deriving newtype IsString
+  deriving newtype ToJSON
+  deriving newtype FromJSON
 
-instance ToJSON ContractName
+-- instance ToJSON ContractName
 
-instance FromJSON ContractName
+-- instance FromJSON ContractName
 
 parseBytes :: MonadThrow m => Text -> Parser a -> B8.ByteString -> m a
 parseBytes name parser b = either (throwM . TextFormatException . msg) pure $ parseOnly (parser <* endOfInput) b

--- a/lib/TXG/Utils.hs
+++ b/lib/TXG/Utils.hs
@@ -204,9 +204,10 @@ post
     => Manager
     -> HostAddress
     -> T.Text
+    -> Bool
     -> body
     -> IO (Either ClientError result)
-post mgr hostAddr urlPath body = do
+post mgr hostAddr urlPath s body = do
     resp <- httpLbs req mgr
     return $ if statusIsSuccessful (responseStatus resp)
         then first (ClientError . T.pack)
@@ -222,7 +223,7 @@ post mgr hostAddr urlPath body = do
   where
     req = defaultRequest
         { method = "POST"
-        , secure = False
+        , secure = s
         , host = T.encodeUtf8 $ hostnameToText $ _hostAddressHost hostAddr
         , port = fromIntegral $ _hostAddressPort hostAddr
         , path = T.encodeUtf8 urlPath
@@ -242,7 +243,7 @@ pactPost
     -> body
     -> IO (Either ClientError result)
 pactPost mgr hostAddr v cid pactPath
-    = post mgr hostAddr (pactBasePath v cid <> pactPath)
+    = post mgr hostAddr (pactBasePath v cid <> pactPath) True
 
 mempoolPost
     :: ToJSON body
@@ -255,7 +256,7 @@ mempoolPost
     -> body
     -> IO (Either ClientError result)
 mempoolPost mgr hostAddr v cid mempoolPath
-    = post mgr hostAddr (mempoolBasePath v cid <> mempoolPath)
+    = post mgr hostAddr (mempoolBasePath v cid <> mempoolPath) False
 
 chainBasePath :: ChainwebVersion -> ChainId -> T.Text
 chainBasePath v cid = basePath v <> "/chain/" <> cidToText cid

--- a/lib/TXG/Utils.hs
+++ b/lib/TXG/Utils.hs
@@ -221,7 +221,7 @@ post mgr hostAddr urlPath body = do
   where
     req = defaultRequest
         { method = "POST"
-        , secure = True
+        , secure = False
         , host = T.encodeUtf8 $ hostnameToText $ _hostAddressHost hostAddr
         , port = fromIntegral $ _hostAddressPort hostAddr
         , path = T.encodeUtf8 urlPath

--- a/lib/TXG/Utils.hs
+++ b/lib/TXG/Utils.hs
@@ -54,6 +54,7 @@ module TXG.Utils
 , poll
 , listen
 , mempoolMember
+, spv
 ) where
 
 import Configuration.Utils
@@ -313,3 +314,15 @@ mempoolMember
     -> IO (Either ClientError [Bool])
 mempoolMember m a v c txh = mempoolPost m a v c "/member" txh
 
+spv
+    :: Manager
+    -> HostAddress
+    -> ChainwebVersion
+    -> ChainId
+    -> RequestKey
+    -> IO (Either ClientError T.Text)
+spv m a v c rk = pactPost m a v c "/spv" $ object
+  [
+    "requestKey" .= rk
+  , "targetChainId" .= c
+  ]

--- a/mptDocker.nix
+++ b/mptDocker.nix
@@ -1,0 +1,22 @@
+{ kpkgs ? import ./deps/kpkgs {}, txg ? import ./. {}, ... }:
+
+let pkgs = kpkgs.pkgs;
+  in pkgs.dockerTools.buildImage {
+  name = "mempool-p2p-tester-with-nix";
+  tag = "latest";
+
+  contents = [pkgs.curl pkgs.sqlite];
+  runAsRoot = ''
+    #!${pkgs.runtimeShell}
+    ${pkgs.dockerTools.shadowSetup}
+    mkdir -p /txg
+  '';
+
+  config = {
+    Cmd = [ "--help" ];
+    WorkingDir = "/txg";
+    Volumes = { "/txg" = { }; };
+    Entrypoint = [ "${pkgs.haskell.lib.justStaticExecutables txg}/bin/mempool-p2p-tester"];
+  };
+
+}

--- a/txg.cabal
+++ b/txg.cabal
@@ -88,6 +88,7 @@ executable txg
     , nonempty-containers  >=0.3
     , pretty-simple        >=2.2 && < 4.0
     , primitive            >=0.6
+    , retry
     , string-conv         >=0.1
     , stm
     , txg

--- a/txg.cabal
+++ b/txg.cabal
@@ -83,6 +83,7 @@ executable txg
   build-depends:
     , async                >=2.2
     , generic-lens         >=1.1
+    , lens-aeson          >= 1.1
     , mwc-random           >=0.14
     , nonempty-containers  >=0.3
     , pretty-simple        >=2.2

--- a/txg.cabal
+++ b/txg.cabal
@@ -86,6 +86,7 @@ executable txg
     , lens-aeson          >= 1.1
     , mwc-random           >=0.14
     , nonempty-containers  >=0.3
+    , parsec
     , pretty-simple        >=2.2 && < 4.0
     , primitive            >=0.6
     , retry

--- a/txg.cabal
+++ b/txg.cabal
@@ -88,6 +88,7 @@ executable txg
     , nonempty-containers  >=0.3
     , pretty-simple        >=2.2
     , primitive            >=0.6
+    , string-conv         >=0.1
     , stm
     , txg
     , yet-another-logger   >=0.3

--- a/txgDocker.nix
+++ b/txgDocker.nix
@@ -1,0 +1,22 @@
+{ kpkgs ? import ./deps/kpkgs {}, txg ? import ./. {}, dockerTag ? "latest", ... }:
+
+let pkgs = kpkgs.pkgs;
+  in pkgs.dockerTools.buildImage {
+  name = "txg-with-nix";
+  tag = dockerTag;
+
+  contents = [pkgs.curl pkgs.sqlite];
+  runAsRoot = ''
+    #!${pkgs.runtimeShell}
+    ${pkgs.dockerTools.shadowSetup}
+    mkdir -p /txg
+  '';
+
+  config = {
+    Cmd = [ "--help" ];
+    WorkingDir = "/txg";
+    Volumes = { "/txg" = { }; };
+    Entrypoint = [ "${pkgs.haskell.lib.justStaticExecutables txg}/bin/txg"];
+  };
+
+}


### PR DESCRIPTION
Given changes in the chainweb api, we need to update the transaction generator for use with devnet. The most important change is moving from using the datatype `HostAddress` to `ChainwebHost` for specifying chainweb-node urls. 

We've also included a docker image for the transaction generator. It can be built by invoking the following command:

```
nix-build txgDocker.nix --argstr dockerTag debug
```



Additionally, we also wish to generate cross chain transfers and give the user the ability to attach keysets to each contract they would like to load.