### PR TITLE
Add tx log to elasticsearch

### DIFF
--- a/exec/TXG.hs
+++ b/exec/TXG.hs
@@ -490,8 +490,8 @@ mkElasticSearchRequest esConf version start end rks = do
       , HTTP.responseTimeout = HTTP.responseTimeoutMicro 5_000_000
       , HTTP.checkResponse = HTTP.throwErrorStatusCodes
       , HTTP.requestHeaders =
-        ("Content-Type", "application/x-ndjson") :
-        maybe [] (\k -> [("Authoriation", "ApiKey " <> T.encodeUtf8 k)]) (esApiKey esConf)
+        ("Content-Type", "application/x-ndjson")
+        : maybe [] (\k -> [("Authorization", "ApiKey " <> T.encodeUtf8 k)]) (esApiKey esConf)
       , HTTP.requestBody = body currentTime
       }
   where


### PR DESCRIPTION
Allow tx log to be sent to elasticsearch instead of stdout. Fix previous error of incorrectly configured command line options.